### PR TITLE
fix: Make flags work properly

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newInitCmd(cfg tester.CmdConfig) *cobra.Command {
+func newInitCmd(cfg *tester.CmdConfig) *cobra.Command {
 	return &cobra.Command{
 		Use:   "init [path to admission policy file]",
 		Short: "Generate skeleton manifests for writing tests",
@@ -32,7 +32,7 @@ func newInitCmd(cfg tester.CmdConfig) *cobra.Command {
 				return fmt.Errorf("path is required")
 			}
 			targetFilePath := args[0]
-			return tester.RunInit(cfg, targetFilePath)
+			return tester.RunInit(*cfg, targetFilePath)
 		},
 	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -41,10 +41,12 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", false, "Verbose output")
 	cmd.PersistentFlags().BoolVarP(&cfg.Debug, "debug", "d", false, "Debug output")
 
-	initLog(cfg)
+	cobra.OnInitialize(func() {
+		initLog(cfg)
+	})
 
-	cmd.AddCommand(newInitCmd(cfg))
-	cmd.AddCommand(newRunCmd(cfg))
+	cmd.AddCommand(newInitCmd(&cfg))
+	cmd.AddCommand(newRunCmd(&cfg))
 	cmd.AddCommand(newVersionCmd())
 	return cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRunCmd(cfg tester.CmdConfig) *cobra.Command {
+func newRunCmd(cfg *tester.CmdConfig) *cobra.Command {
 	return &cobra.Command{
 		Use:   "run [path to test manifest]...",
 		Short: "Run the tests of ValidatingAdmissionPolicy",
@@ -31,7 +31,7 @@ func newRunCmd(cfg tester.CmdConfig) *cobra.Command {
 			if len(args) == 0 {
 				return fmt.Errorf("path is required")
 			}
-			return tester.Run(cfg, args)
+			return tester.Run(*cfg, args)
 		},
 	}
 }

--- a/internal/tester/result.go
+++ b/internal/tester/result.go
@@ -84,12 +84,11 @@ func (r *policyEvalResult) String(verbose bool) string {
 	}
 	summary += fmt.Sprintf(" - %s ==> %s", strings.ToUpper(string(r.TestCase.Expect)), strings.ToUpper(string(r.Result)))
 
-	if !verbose {
-		return summary
-	}
-
 	out := []string{summary}
 	for _, d := range r.Decisions {
+		if r.Pass() && !verbose {
+			continue
+		}
 		// Workaround to handle the case where the evaluation is not set
 		// TODO remove this workaround after htcps://github.com/kubernetes/kubernetes/pull/126867 is released
 		if d.Evaluation == "" {


### PR DESCRIPTION
Problem: The verbose flag and debug flag do not work and there are no effects even when they are set.

I've addressed this issue by providing `CmdConfig` struct by a pointer to each sub-command factory func, then they are properly populated when Cobra sets command-line parameters to these fields.

In addition, I've fixed the issue that no detailed messages are shown when tests fail if the verbose flag is not set.
