### PR TITLE
VAP: add 'deniedMessage' field to validate MessageExpression

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ vapTestSuites:
       groups: <groups>
       extra: ...
     expect: <allow|deny|skip|error>
+    deniedMessage: # Optional: check message when deny expected.
 mapTestSuites:
 - policy: <name> # MutatingAdmissionPolicy's name
   tests:

--- a/examples/complicated/complicated-policy.test/kaptest.yaml
+++ b/examples/complicated/complicated-policy.test/kaptest.yaml
@@ -19,6 +19,7 @@ vapTestSuites:
     param:
       name: config
     expect: deny
+    deniedMessage: "replicas must be less than 6"
 - policy: policy-with-namespace
   tests:
   - object:
@@ -31,6 +32,7 @@ vapTestSuites:
       name: bad-deployment-with-namespace
       namespace: foo
     expect: deny
+    deniedMessage: "replicas must be less than 5"
 mapTestSuites:
 - policy: policy-with-params
   tests:

--- a/examples/complicated/complicated-policy.yaml
+++ b/examples/complicated/complicated-policy.yaml
@@ -39,7 +39,7 @@ spec:
     expression: "'max-replicas' in variables.labels ? int(variables.labels['max-replicas']) : 1"
   validations:
   - expression: object.spec.replicas <= variables.maxReplicas
-    messageExpression: "'replicas must be less than ' + variables.maxReplicas"
+    messageExpression: "'replicas must be less than ' + string(variables.maxReplicas)"
 ---
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: MutatingAdmissionPolicy

--- a/examples/simple/simple-policy.test/kaptest.yaml
+++ b/examples/simple/simple-policy.test/kaptest.yaml
@@ -13,6 +13,7 @@ vapTestSuites:
       kind: Deployment
       name: bad-deployment
     expect: deny
+    deniedMessage: "replicas must be equal or less than 5, but got 6"
 - policy: error-policy
   tests:
   - object:

--- a/examples/simple/simple-policy.yaml
+++ b/examples/simple/simple-policy.yaml
@@ -11,6 +11,7 @@ spec:
       resources: ["deployments"]
   validations:
   - expression: object.spec.replicas <= 5
+    messageExpression: "'replicas must be equal or less than 5, but got ' + string(object.spec.replicas)"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy

--- a/internal/tester/manifest.go
+++ b/internal/tester/manifest.go
@@ -75,8 +75,7 @@ type VAPTestCase struct {
 	Param     NamespacedName       `yaml:"param,omitempty"`
 	Expect    PolicyDecisionExpect `yaml:"expect,omitempty"`
 	UserInfo  UserInfo             `yaml:"userInfo,omitempty"`
-	// TODO: Support message test
-	// Message   string                              `yaml:"message"`
+	DeniedMsg string               `yaml:"deniedMessage"`
 }
 
 var _ TestCase = &VAPTestCase{}

--- a/internal/tester/result.go
+++ b/internal/tester/result.go
@@ -47,9 +47,15 @@ var _ testResult = &vapEvalResult{}
 
 func newVAPEvalResult(policy string, tc VAPTestCase, decisions []validating.PolicyDecision) *vapEvalResult {
 	result := validating.EvalAdmit
-	for _, d := range decisions {
+	for i, d := range decisions {
 		if d.Evaluation == validating.EvalDeny {
-			result = validating.EvalDeny
+			if tc.DeniedMsg != "" && tc.DeniedMsg != d.Message {
+				result = validating.EvalError
+				decisions[i].Message = fmt.Sprintf("message '%s' expected but got '%s'", tc.DeniedMsg, d.Message)
+				break
+			} else {
+				result = validating.EvalDeny
+			}
 		} else if d.Evaluation == validating.EvalError {
 			result = validating.EvalError
 			break

--- a/internal/tester/testdata/vap-custom-resources.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-custom-resources.test/kaptest.yaml
@@ -15,3 +15,4 @@ vapTestSuites:
       kind: HTTPProxy
       name: bad
     expect: deny
+    deniedMessage: "IngressClass must be 'contour'."

--- a/internal/tester/testdata/vap-standard-resources.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-standard-resources.test/kaptest.yaml
@@ -28,6 +28,7 @@ vapTestSuites:
       kind: Deployment
       name: mutable
     expect: deny
+    deniedMessage: "specified replicas 6 exceeds limit 5"
 - policy: deployment-check-immutable
   tests:
   - object:

--- a/internal/tester/testdata/vap-standard-resources.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-standard-resources.test/kaptest.yaml
@@ -13,6 +13,7 @@ vapTestSuites:
       kind: Deployment
       name: bad
     expect: deny
+    deniedMessage: "specified replicas 6 exceeds limit 5"
   - object:
       kind: Deployment
       name: ok

--- a/internal/tester/testdata/vap-standard-resources.test/unexpected-denied-msg.yaml
+++ b/internal/tester/testdata/vap-standard-resources.test/unexpected-denied-msg.yaml
@@ -1,0 +1,15 @@
+policies:
+- ../vap-standard-resources.yaml
+resources:
+- resources.yaml
+vapTestSuites:
+- policy: deployment-replicas
+  tests:
+  - object:
+      kind: Deployment
+      name: bad
+    oldObject:
+      kind: Deployment
+      name: mutable
+    expect: deny
+    deniedMessage: "specified replicas exceeds limit 5"

--- a/internal/tester/testdata/vap-standard-resources.yaml
+++ b/internal/tester/testdata/vap-standard-resources.yaml
@@ -11,6 +11,7 @@ spec:
       resources: ["deployments"]
   validations:
   - expression: object.spec.replicas <= 5
+    messageExpression: "'specified replicas '+ string(object.spec.replicas) +' exceeds limit 5'"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy

--- a/internal/tester/testdata/vap-with-namespaces.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-with-namespaces.test/kaptest.yaml
@@ -15,3 +15,4 @@ vapTestSuites:
       name: bad
       namespace: foo
     expect: deny
+    deniedMessage: "replicas must be equal or less than 5"

--- a/internal/tester/testdata/vap-with-namespaces.yaml
+++ b/internal/tester/testdata/vap-with-namespaces.yaml
@@ -17,4 +17,4 @@ spec:
     expression: "'max-replicas' in variables.annotations ? int(variables.annotations['max-replicas']) : 0"
   validations:
   - expression: object.spec.replicas <= variables.maxReplicas
-    messageExpression: "'replicas must be equal or less than ' + variables.maxReplicas"
+    messageExpression: "'replicas must be equal or less than ' + string(variables.maxReplicas)"

--- a/internal/tester/testdata/vap-with-params.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-with-params.test/kaptest.yaml
@@ -17,3 +17,4 @@ vapTestSuites:
     param:
       name: config1
     expect: deny
+    deniedMessage: "replicas must be equal or less than 5"

--- a/internal/tester/testdata/vap-with-params.yaml
+++ b/internal/tester/testdata/vap-with-params.yaml
@@ -18,4 +18,4 @@ spec:
     name: replicas
   validations:
   - expression: variables.replicas <= int(params.data.maxReplicas)
-    messageExpression: "'replicas must be equal or less than ' + params.data.maxReplicas"
+    messageExpression: "'replicas must be equal or less than ' + string(params.data.maxReplicas)"

--- a/internal/tester/testdata/vap-with-userinfo.test/kaptest.yaml
+++ b/internal/tester/testdata/vap-with-userinfo.test/kaptest.yaml
@@ -17,3 +17,4 @@ vapTestSuites:
     userInfo:
       name: 'system:serviceaccount:foo:default'
     expect: deny
+    deniedMessage: "system:serviceaccount:foo:default is not allowed to create or update deployments"

--- a/internal/tester/tester_test.go
+++ b/internal/tester/tester_test.go
@@ -134,6 +134,14 @@ func TestRun(t *testing.T) {
 			wantErr:           nil,
 			validateManifests: false,
 		},
+		{
+			name: "err: unexpected message output",
+			args: []string{
+				"./testdata/vap-standard-resources.test/unexpected-denied-msg.yaml",
+			},
+			wantErr:           ErrTestFail,
+			validateManifests: true,
+		},
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
This PR adds `deniedMessage` field to validate MessageExpression outputs.

## Changes
- `deniedMessage` field is added to VAP test definition.